### PR TITLE
revert: tailwind and tailwind prettier plugin updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
         "is-ci": "^3.0.1",
         "prettier": "^3.3.3",
         "prettier-plugin-astro": "^0.14.1",
-        "prettier-plugin-tailwindcss": "0.6.6",
+        "prettier-plugin-tailwindcss": "0.6.5",
         "pretty-quick": "^4.0.0",
-        "tailwindcss": "3.4.10",
+        "tailwindcss": "3.4.6",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.4.5"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4649,9 +4649,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-tailwindcss@npm:0.6.6":
-  version: 0.6.6
-  resolution: "prettier-plugin-tailwindcss@npm:0.6.6"
+"prettier-plugin-tailwindcss@npm:0.6.5":
+  version: 0.6.5
+  resolution: "prettier-plugin-tailwindcss@npm:0.6.5"
   peerDependencies:
     "@ianvs/prettier-plugin-sort-imports": "*"
     "@prettier/plugin-pug": "*"
@@ -4664,7 +4664,6 @@ __metadata:
     prettier-plugin-import-sort: "*"
     prettier-plugin-jsdoc: "*"
     prettier-plugin-marko: "*"
-    prettier-plugin-multiline-arrays: "*"
     prettier-plugin-organize-attributes: "*"
     prettier-plugin-organize-imports: "*"
     prettier-plugin-sort-imports: "*"
@@ -4691,8 +4690,6 @@ __metadata:
       optional: true
     prettier-plugin-marko:
       optional: true
-    prettier-plugin-multiline-arrays:
-      optional: true
     prettier-plugin-organize-attributes:
       optional: true
     prettier-plugin-organize-imports:
@@ -4703,7 +4700,7 @@ __metadata:
       optional: true
     prettier-plugin-svelte:
       optional: true
-  checksum: 10/7e536ed7fc60fa0cd5ea515f16cc638f1ed242c9a72a58fda7b795c1f905623a12debe8cff312f15b06cd66a398e7b4f4b07dd549cead5df6e26064fde3c61c7
+  checksum: 10/49b5a12f8bd74a6558b28c7d7f6f323c1a1fc523701f6768552bac9c18e92a213d375ad0a00ce71c943c80571b40d10c2b6c6299c08d581d4637165aee9dda24
   languageName: node
   linkType: hard
 
@@ -5229,12 +5226,12 @@ __metadata:
     lucide-react: "npm:^0.435.0"
     prettier: "npm:^3.3.3"
     prettier-plugin-astro: "npm:^0.14.1"
-    prettier-plugin-tailwindcss: "npm:0.6.6"
+    prettier-plugin-tailwindcss: "npm:0.6.5"
     pretty-quick: "npm:^4.0.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     tailwind-merge: "npm:^2.4.0"
-    tailwindcss: "npm:3.4.10"
+    tailwindcss: "npm:3.4.6"
     tailwindcss-animate: "npm:^1.0.7"
     typescript: "npm:^5.4.5"
   languageName: unknown
@@ -5599,9 +5596,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:3.4.10":
-  version: 3.4.10
-  resolution: "tailwindcss@npm:3.4.10"
+"tailwindcss@npm:3.4.6":
+  version: 3.4.6
+  resolution: "tailwindcss@npm:3.4.6"
   dependencies:
     "@alloc/quick-lru": "npm:^5.2.0"
     arg: "npm:^5.0.2"
@@ -5628,7 +5625,7 @@ __metadata:
   bin:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
-  checksum: 10/5296111e7b0c3e638f3a136a0eb13ab4048c5c5ef5e72b055ae6a0f811502e99478218958bfbbf49b3ed8cf07f395fc893589033a893087e299c084fec8efcac
+  checksum: 10/bd550628cc2a5e80b0543738320ff1e3377e1eb8b4ea6aa3774d479b4e88926eb18828416570859dbe38b12af0e4ea2f97deda5a6449d1f0985936046fcc7a47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts SerenModz21/serenmodz.rocks#322

these updates as mentioned in https://github.com/SerenModz21/serenmodz.rocks/commit/ec6ad98784b2191ec26fdf83201848983eb681a6 cause the following issue:

```
[error] Cannot find package '@ianvs/prettier-plugin-sort-imports' imported from [redacted]\serenmodz.rocks\node_modules\prettier-plugin-tailwindcss\dist\index.mjs
[error] Did you mean to import "@ianvs/prettier-plugin-sort-imports/lib/src/index.js"?
```